### PR TITLE
Add `make_scalar` to `obs["mean"]`

### DIFF
--- a/src/resulttools/ResultTools.jl
+++ b/src/resulttools/ResultTools.jl
@@ -23,7 +23,7 @@ function measurement_from_obs(obsname, obs)
         @warn "$obsname: autocorrelation time longer than rebin length. Results may be unreliable."
     end
 
-    mean = obs["mean"]
+    mean = make_scalar(obs["mean"])
     if mean isa AbstractDict
         mean = Complex(mean["re"], mean["im"])
     end


### PR DESCRIPTION
Sometimes JSON parses complex mean results to
```julia
infil> v
1-element Vector{Any}:
 Dict{String, Any}("re" => -0.4291808245601345, "im" => 0.0)
```

To avoid this, I add `make_scalar` to ensure `mean` is a `AbstractDict`. This shall not break anything.