### PR TITLE
parallel_tempering: fix restart errors

### DIFF
--- a/src/parallel_tempering.jl
+++ b/src/parallel_tempering.jl
@@ -350,6 +350,7 @@ function Carlo.read_checkpoint!(
         end
     else
         chain_permutation = nothing
+        parallel_measures = nothing
     end
 
     mc.chain_idx = MPI.scatter(chain_permutation, comm)

--- a/test/test_parallel_tempering.jl
+++ b/test/test_parallel_tempering.jl
@@ -92,5 +92,32 @@ MPI.Comm_rank(f::FakeComm) = f.rank
             end
         end
 
+        @testset "restart" begin
+            μs = [0, 1, 1.5, 1.7]
+            pt_kwargs = (;
+                mc = ParallelTemperingMC,
+                ranks_per_run = length(μs),
+                ntasks = 1,
+                binsize = 200,
+                thermalization = 1000,
+                parallel_tempering = (;
+                    mc = TestTemperedMC,
+                    parameter = :μ,
+                    values = μs,
+                    interval = 1,
+                ),
+            )
+
+            job_half = make_test_job("$tmpdir/parallel_tempering_restart", 5000; pt_kwargs...)
+            run_test_job_mpi(job_half; num_ranks = length(μs) + 1)
+
+            job_full = make_test_job("$tmpdir/parallel_tempering_restart", 10000; pt_kwargs...)
+            run_test_job_mpi(job_full; num_ranks = length(μs) + 1)
+            tasks = JT.read_progress(job_full)
+            for task in tasks
+                @test task.sweeps >= task.target_sweeps
+            end
+        end
+
     end
 end


### PR DESCRIPTION
## Summary
Fixes a bug that occurs when restarting a parallel tempering run from a checkpoint.

## Changes
- Fix `UndefVarError: parallel_measures not defined` on restart
- Initialize `parallel_measures = nothing` in `Carlo.read_checkpoint!` in `parallel_tempering.jl`

## Reproduction
1. Run `mpiexecjl -n 8 julia parallel_tempering.jl run` with a short wall time so that a checkpoint is written.
2. Restart from the checkpoint by rerunning:
   `mpiexecjl -n 8 julia parallel_tempering.jl run`

The script `parallel_tempering.jl` used for reproduction is shown below:
```
using Carlo
using Carlo.JobTools
using Ising

tm = TaskMaker()

tm.sweeps = 200000
tm.thermalization = 2000
tm.binsize = 100

Ts = range(1.5, 4, 7)

# contract temperatures around Tc for better distribution overlap
Tc = 2.269
Ts += 0.5 .* (Tc .- Ts) ./ (0.6 .+ (Tc .- Ts) .^ 2)


tm.parallel_tempering = (mc = Ising.MC, parameter = :T, values = Ts, interval = 1)

Ls = [32, 64]
for L in Ls
    tm.Lx = L
    tm.Ly = L

    # tm.T is set implicitly by ParallelTemperingMC

    task(tm)
end

job = JobInfo(
    splitext(@__FILE__)[1],
    ParallelTemperingMC; # the underlying model MC is set in tm.parallel_tempering.mc
    run_time = "00:00:30",
    checkpoint_time = "00:10",
    tasks = make_tasks(tm),
    ranks_per_run = length(tm.parallel_tempering.values), # needs to match!
)

start(job, ARGS)
```

#Error output
On restart, the run fails with:
```
UndefVarError: `parallel_measures` not defined in local scope
``` 