### PR TITLE
Change default Parellel Tempering Tag

### DIFF
--- a/src/parallel_tempering.jl
+++ b/src/parallel_tempering.jl
@@ -1,6 +1,6 @@
 # MPI tags
-const PT_WEIGHT_MSG = 4573792
-const PT_SWITCH_MSG = 4573793
+const PT_WEIGHT_MSG = 524287
+const PT_SWITCH_MSG = 524287 
 
 struct ParallelMeasurements
     queue::Vector{Tuple{Symbol,Any}}

--- a/src/parallel_tempering.jl
+++ b/src/parallel_tempering.jl
@@ -1,5 +1,5 @@
 # MPI tags
-const PT_WEIGHT_MSG = 524287
+const PT_WEIGHT_MSG = 524286
 const PT_SWITCH_MSG = 524287 
 
 struct ParallelMeasurements

--- a/src/parallel_tempering.jl
+++ b/src/parallel_tempering.jl
@@ -1,6 +1,6 @@
 # MPI tags
-const PT_WEIGHT_MSG = 524286
-const PT_SWITCH_MSG = 524287 
+const PT_WEIGHT_MSG = 32732
+const PT_SWITCH_MSG = 32733 
 
 struct ParallelMeasurements
     queue::Vector{Tuple{Symbol,Any}}


### PR DESCRIPTION
Intel MPI only permits MPI tag less then 2^19-1 
```bash
$ zsh -lc 'source /opt/intel/oneapi/setvars.sh >/dev/null 2>&1 && julia --project=. -e "using MPI; MPI.Init(); println(MPI.tag_ub()); MPI.Finalize()"'
524287
```
According to the MPI standard, MPI_TAG_UB is only guaranteed to be at least 32767.

Up to this use case, I'd like to set to intel limit for now, do you think 32767 is still safe enough?